### PR TITLE
Migrate to `ccpbiosim` Organisaion

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,7 +32,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          environment-file: environment.yml
+          environment-file: environment.yaml
           activate-environment: prep
           auto-update-conda: true
           auto-activate-base: false

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,35 +3,52 @@
 
 name: prepmd CI
 
-env:
-  KEY_MODELLER: MODELIRANJE
-
 on:
-  workflow_dispatch:
-  pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
 
 jobs:
   tests:
-    name: tests
+    name: Run tests
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.13']
+        os: [ubuntu-24.04, windows-2025, macos-15]
+        python-version: ["3.13"]
 
-    runs-on: $${{ matrix.platform }}
+    env:
+      KEY_MODELLER: MODELIRANJE
 
     steps:
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniconda-version: "latest"
+      - name: Checkout repo
+        uses: actions/checkout@v5.0.0
 
-    - name: tests
-      run: |
-        conda env create -f environment.yml
-        conda activate prep
-        conda install pytest
-        pytest
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          environment-file: environment.yml
+          activate-environment: prep
+          auto-update-conda: true
+          auto-activate-base: false
+
+      - name: Verify conda environment
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
+      - name: Install additional testing dependencies
+        shell: bash -l {0}
+        run: |
+          conda install -y pytest pytest-cov
+
+      - name: Run test suite
+        shell: bash -l {0}
+        run: |
+          pytest --cov=prepmd --cov-report=term-missing --cov-append .

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A utility to automatically prepare structures from the PDB for molecular dynamic
 
 ## Installation
 * Install [Conda](https://conda-forge.org/download/) (if you don't already have it)
-* Clone this repo and enter the folder: `git clone git@github.com:HECBioSim/prepmd.git && cd prepmd` 
+* Clone this repo and enter the folder: `git clone https://github.com/CCPBioSim/mdprep.git && cd prepmd` 
 * Run `conda env create --name prepmd --file environment.yaml && conda activate prepmd && pip install .`
 * For the modeller part of the workflow to work, you need to get a [modeller license key](https://salilab.org/modeller/registration.html) and add it to modeller's config.py file. If you use conda, the key will be in `envs/prepmd/lib/modeller-10.7/modlib/modeller/config.py` relative to the path where conda is installed.
 


### PR DESCRIPTION
## Summary
This PR updates the `mdprep` GitHub Actions workflow to fix test execution issues and align the repository with the `CCPBioSim` organisation.  The workflow was previously hanging during the testing stage, and several configuration updates were required to ensure smooth CI runs and correct organisational references.

---

## Changes

### Change 1: Fix and modernise CI workflow
- Updated `.github/workflows/python-app.yml` to resolve hanging tests.
- Ensured Conda environment creation and activation work correctly across all OS platforms (Ubuntu, macOS, Windows).
- Added diagnostic steps (`conda info`, `conda list`) for debugging during CI runs.
- Confirmed pytest runs successfully with coverage reporting enabled.

### Change 2: Update organisation references
- Updated all repository and configuration references from `hecbiosim` → `CCPBioSim`.

---

## Impact
- CI workflow for `mdprep` now runs successfully and consistently across all supported platforms.  
- Streamlines automated testing and improves maintainability.  
- Aligns repository and workflows under the `CCPBioSim` organisation for better integration and visibility.
