### PR TITLE
Fix Conda build failure due to missing conda-build in GitHub Actions environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           miniforge-variant: Miniforge3
           python-version: "3.13.2"
-          auto-activate: false
+          auto-activate: true
+          activate-environment: base
           conda-remove-defaults: true
           channels: conda-forge,salilab
           channel-priority: strict
@@ -57,6 +58,8 @@ jobs:
         run: |
           conda install -y conda-build anaconda-client
           conda config --set anaconda_upload no
+          conda list conda-build
+          conda build --help
 
       - name: Build package
         shell: bash -l {0}


### PR DESCRIPTION
## Summary
This PR addresses a GitHub Actions CI issue where Conda tooling (e.g. `conda-build`) is installed but not reliably available during workflow execution due to inconsistent environment activation across steps.

---

## Changes

### Standardised Conda environment activation in CI:
- Ensured Conda environments are consistently activated across all workflow steps
- Configured `setup-miniconda` to reliably activate the intended environment (e.g. `base` or target env)
- Enabled automatic environment activation to prevent step-to-step state loss
- Added basic sanity checks (e.g. `conda list`, `conda build --help`) to verify Conda tooling availability during CI runs
- Improved reproducibility of Conda-based builds in GitHub Actions

---

## Impact
- Improves reliability of Conda-based CI workflows across repositories
- Eliminates intermittent failures caused by environment activation inconsistencies
- Aligns CI behaviour more closely with local development environments
- Makes Conda setup issues easier to detect and debug early in pipeline execution
- Provides a standard pattern that can be reused across multiple repositories in the organisation