### PR TITLE
Add Coveralls coverage reporting

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -52,14 +52,35 @@ jobs:
           conda info
           conda list
 
-      - name: install with pip
+      - name: Install package and test dependencies
         shell: bash -l {0}
         run: |
-            which pip
-            pip install -e .
-            conda list
+          which pip
+          pip install -e .
+          pip install pytest-cov
+          conda list
 
-      - name: Run test suite
+      - name: Run test suite with coverage
         shell: bash -l {0}
-        #run: prep-license ${{ secrets.MODELLER_KEY }} && pytest -v # no valid modeller key
-        run: pytest -v
+        run: |
+          pytest -v --cov=prepmd --cov-report=term-missing --cov-report=lcov
+
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.lcov
+          flag-name: ${{ matrix.os }}-py${{ matrix.python-version }}
+          parallel: true
+          fail-on-error: false
+
+  coveralls:
+    name: Finalise Coveralls
+    needs: tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
## Summary

This PR adds Coveralls coverage reporting to the existing `prepmd` CI workflow.

The test suite now runs with coverage enabled using `pytest-cov`, and coverage reports are uploaded to Coveralls as part of the GitHub Actions workflow.

## Changes

### Add coverage collection to CI:
* Installed `pytest-cov` as part of the CI test dependencies.
* Updated the test command to run with coverage enabled for the `prepmd` package.
* Added terminal coverage reporting with missing lines shown.
* Generated an `lcov` coverage report for upload.

### Add Coveralls reporting:
* Added the Coveralls GitHub Action to upload coverage results.
* Configured coverage uploads for the CI matrix.
* Added a final Coveralls completion job for parallel matrix builds.

## Impact
* Improves visibility of test coverage in the project.
* Makes it easier to monitor coverage changes over time.
* Helps identify areas of the codebase that may need additional tests.
* Does not change package functionality or runtime behaviour.
