### PR TITLE
Add Zenodo DOI Citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |----------------|--------|
 | **Build**      | [![prepmd CI](https://github.com/CCPBioSim/prepmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/CCPBioSim/prepmd/actions/workflows/python-app.yml) |
 | **Documentation** |[![Docs - Status](https://app.readthedocs.org/projects/prepmd/badge/?version=latest)](https://prepmd.readthedocs.io/en/latest/?badge=latest) |
-| **Citation**      |  |
+| **Citation**      | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21536438.svg)](https://doi.org/10.5281/zenodo.21536438) |
 | **Anaconda**       | [![Anaconda.org](https://anaconda.org/CCPBioSim/prepmd/badges/version.svg)](https://anaconda.org/CCPBioSim/prepmd/) [![Last Updated](https://anaconda.org/CCPBioSim/prepmd/badges/latest_release_date.svg)](https://anaconda.org/CCPBioSim/prepmd) [![Platforms](https://anaconda.org/CCPBioSim/prepmd/badges/platforms.svg)](https://anaconda.org/CCPBioSim/prepmd) [![License](https://anaconda.org/CCPBioSim/prepmd/badges/license.svg)](https://anaconda.org/CCPBioSim/prepmd) [![Downloads](https://anaconda.org/CCPBioSim/prepmd/badges/downloads.svg)](https://anaconda.org/CCPBioSim/prepmd)|
 | **Quality**    | [![Coverage Status](https://coveralls.io/repos/github/CCPBioSim/prepmd/badge.svg?branch=main)](https://coveralls.io/github/CCPBioSim/prepmd?branch=main) |
 


### PR DESCRIPTION
## Summary
This PR will add the official Zenodo DOI for `prepmd` to the GitHub README.

## Changes

### Add DOI citation:
* Added the Zenodo DOI to the README.

## Impact
* Makes it easier for users to cite `prepmd`.
